### PR TITLE
Fix: User Guides - API Integration hyperlink references

### DIFF
--- a/docs/guides/api-integration.md
+++ b/docs/guides/api-integration.md
@@ -527,9 +527,9 @@ def monitor_api_call(prompt, workflow):
 ## Additional Resources
 
 - [Workflow Requirements](../workflows/README.md) - Understand configuration needs
-- [Configuration Guide](/getting-started/configuration) - Detailed setup instructions
+- [Configuration Guide](../getting-started/configuration.md) - Detailed setup instructions
 - [Custom Agents](../extensions/custom-agents.md) - Create your own workflows
-- [Troubleshooting](/troubleshooting/) - Common issues and solutions
+- [Troubleshooting](../troubleshooting/README.md) - Common issues and solutions
 
 ---
 


### PR DESCRIPTION
Updated the following documentation links to reflect the correct relative paths:

1. Configuration Guide
2. Troubleshooting