### PR TITLE
Docs Update: Remove duplicate title

### DIFF
--- a/docs/guides/web-interface.md
+++ b/docs/guides/web-interface.md
@@ -9,8 +9,6 @@ toc_label: "Web Interface"
 toc_icon: "globe"
 ---
 
-#  Web Interface Guide
-
 ## API Integration
 
 ### Using the REST API


### PR DESCRIPTION
Web interface.md has duplicate `Web Interface Guide` title text. 

<img width="596" height="226" alt="image" src="https://github.com/user-attachments/assets/9bde0154-4383-432d-afea-2858eb7fa23f" />
