### PR TITLE
Fix: Docs relative path for references

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -320,7 +320,7 @@ The Insight Ingenious API provides powerful endpoints for creating and managing 
 - **Content-Type**: `application/json`
 - **Authentication**: JWT Bearer Token (configurable - disabled by default)
 
-### [Workflow API](/api/workflows)
+### [Workflow API](./WORKFLOWS.md)
 Complete documentation for all available workflow endpoints, including:
 - Classification and routing workflows
 - Multi-agent bike sales analysis (template workflow)
@@ -906,13 +906,13 @@ Example error response:
 
 ## Additional Resources
 
-- [Workflow API Documentation](/api/workflows)
-- [Configuration Guide](/getting-started/configuration)
-- [Development Setup](/development/)
-- [CLI Reference](/CLI_REFERENCE)
+- [Workflow API Documentation](./WORKFLOWS.md)
+- [Configuration Guide](../getting-started/configuration.md)
+- [Development Setup](../development/README.md)
+- [CLI Reference](../CLI_REFERENCE.md)
 
 ## Need Help?
 
-- Check the [troubleshooting guide](/troubleshooting/)
-- Review the [workflow examples](/api/workflows)
+- Check the [troubleshooting guide](../troubleshooting/README.md)
+- Review the [workflow examples](./WORKFLOWS.md)
 - Open an issue on [GitHub](https://github.com/Insight-Services-APAC/ingenious/issues)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -726,7 +726,7 @@ flowchart TD
 
 ## Next Steps
 
-- Read the [Architecture Guide](/architecture/) for system design
-- Check the [Configuration Guide](/getting-started/configuration/) for setup
-- Try the [Getting Started Guide](/getting-started/) for quick setup
-- Explore the [API Documentation](/api/) for integration
+- Read the [Architecture Guide](../architecture/README.md) for system design
+- Check the [Configuration Guide](../getting-started/configuration.md) for setup
+- Try the [Getting Started Guide](../getting-started/README.md) for quick setup
+- Explore the [API Documentation](../api/README.md) for integration

--- a/docs/quick_onboarding/README.md
+++ b/docs/quick_onboarding/README.md
@@ -66,10 +66,10 @@ Insight Ingenious is an enterprise-grade Python library for building AI agent AP
 
 ## Next Steps
 
-- [Detailed Getting Started Guide](../getting-started/)
-- [Configuration Guide](/getting-started/configuration)
-- [API Integration Guide](../guides/api-integration/)
-- [Development Guide](../development/)
+- [Detailed Getting Started Guide](../getting-started/README.md)
+- [Configuration Guide](../getting-started/configuration.md)
+- [API Integration Guide](../guides/api-integration.md)
+- [Development Guide](../development/README.md)
 
 ## Common Tasks
 
@@ -90,6 +90,6 @@ tail -f server.log
 
 ## Getting Help
 
-- [Troubleshooting Guide](../troubleshooting/)
-- [CLI Reference](/CLI_REFERENCE)
-- [API Documentation](../api/)
+- [Troubleshooting Guide](../troubleshooting/README.md)
+- [CLI Reference](../CLI_REFERENCE.md)
+- [API Documentation](../api/README.md)

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -497,7 +497,7 @@ flowchart TD
 5. **Monitor**: Track performance and optimize as needed
 
 For detailed setup instructions, see:
-- [Configuration Guide](/getting-started/configuration) - Complete setup instructions
-- [Getting Started](/getting-started/) - Quick start tutorial
-- [Development Guide](/development/) - Advanced customization
-- [API Documentation](/api/) - Integration details
+- [Configuration Guide](../getting-started/configuration.md) - Complete setup instructions
+- [Getting Started](../getting-started/README.md) - Quick start tutorial
+- [Development Guide](../development/README.md) - Advanced customization
+- [API Documentation](../api/README.md) - Integration details


### PR DESCRIPTION
All references from the `Developer Guide` section, starting from the `Development Setup` tab and up to the `Additional Resources` section `Comprehensive Troubleshooting` tab, have been corrected in this branch.