### PR TITLE
fix: install docs dependencies in documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --extra docs
       - name: Build documentation
         run: |
           uv run mkdocs build --strict
@@ -71,7 +71,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --extra docs
       - name: Build documentation
         run: |
           uv run mkdocs build


### PR DESCRIPTION
## Summary
Fixes the failing documentation build workflow caused by missing MkDocs plugin dependencies.

## Problem
The documentation workflow was failing with:
```
ERROR - Config value 'plugins': The "mkdocs-nav-weight" plugin is not installed
```

## Root Cause
During the recent dependency reorganization, MkDocs plugins were moved from core dependencies to the `docs` optional dependency group in `pyproject.toml`. However, the GitHub Actions workflow was still only running `uv sync` without the `--extra docs` flag, causing the required plugins to not be installed.

## Solution
Updated the workflow to install docs dependencies:
```yaml
- name: Install dependencies
  run: |
    uv sync --extra docs
```

## Testing
- [x] Verified locally that `uv sync --extra docs` installs mkdocs-nav-weight
- [x] Confirmed `uv run mkdocs build --strict` works with the fix
- [x] This should resolve the failing CI builds

🤖 Generated with [Claude Code](https://claude.ai/code)