### PR TITLE
chore: bump version to 0.2.6 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ingenious"
-version = "0.2.5"
+version = "0.2.6"
 description = "An enterprise-grade Python library for quickly setting up APIs to interact with AI Agents"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bumps version from 0.2.5 to 0.2.6 to fix PyPI push failure
- Version 0.2.5 already exists on PyPI, preventing successful deployment

## Background
The GitHub Actions PyPI publish workflow was failing with error:
> File already exists ('ingenious-0.2.5-py3-none-any.whl')

## Changes in this release
This version includes recent improvements from commits:
- Reorganized dependency groups for modular installations
- Enhanced documentation with better configuration guidance  
- Updated dependency lock file
- Azure CLI commands for resource information retrieval

## Test plan
- [x] Version bump applied to pyproject.toml
- [x] Commit message follows conventional format
- [ ] GitHub Actions PyPI workflow will succeed after merge

🤖 Generated with [Claude Code](https://claude.ai/code)